### PR TITLE
Ensure pointer cast is safe

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -85,6 +85,7 @@ use crate::{TiEnumerated, TiRangeBounds, TiSlice};
 /// [`AsRef`]: https://doc.rust-lang.org/std/convert/trait.AsRef.html
 /// [`AsMut`]: https://doc.rust-lang.org/std/convert/trait.AsMut.html
 /// [`derive_more`]: https://crates.io/crates/derive_more
+#[repr(transparent)]
 pub struct TiVec<K, V> {
     /// Raw slice property
     pub raw: Vec<V>,


### PR DESCRIPTION
You're casting `&Vec<T>` to `&TiVec<T>`, but Rust guarantees this only for `repr(transparent)` structs. It's fine to have the second field — zero-sized fields don't count for transparency.