### PR TITLE
Add `tivec![]` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `tivec![]` macro
 
 ## [3.1.0] - 2022-09-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0] - 2022-09-02
 ### Changed
-- `The minimum supported Rust version has been increased to 1.46.0.
+- The minimum supported Rust version has been increased to 1.46.0.
 - `#[repr(transparent)]` added to `TiSlice` and `TiVec` collections.
 
 ## [3.0.3] - 2020-05-27


### PR DESCRIPTION
Hi! I really like this crate and I'm looking into adopting it into a large codebase. 

I noticed that a macro similar to `vec![]` is currently missing. While it's possible to call `vec![..].into()` to produce the same result, I think it's more concise and clear to use `tivec![..]`. I hope you like it!