### PR TITLE
Add bincode support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["collection", "index", "no_std", "slice", "vec"]
 
 [features]
 default = ["alloc", "std"]
-alloc = ["serde?/alloc"]
-std = ["alloc", "serde?/std"]
+alloc = ["serde?/alloc", "bincode?/alloc"]
+std = ["alloc", "serde?/std", "bincode?/std"]
 serde = ["dep:serde"]
 bincode = ["dep:bincode"]
 serde-alloc = ["alloc", "serde"] # Deprecated.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,17 @@ default = ["alloc", "std"]
 alloc = ["serde?/alloc"]
 std = ["alloc", "serde?/std"]
 serde = ["dep:serde"]
+bincode = ["dep:bincode"]
 serde-alloc = ["alloc", "serde"] # Deprecated.
 serde-std = ["std", "serde"] # Deprecated.
 
 [dependencies.serde]
 version = "1.0.210"
 default-features = false
+optional = true
+
+[dependencies.bincode]
+version = "2.0.1"
 optional = true
 
 [dev-dependencies]

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -15,11 +15,12 @@ use core::{fmt, slice};
 #[cfg(feature = "std")]
 use std::io::{IoSlice, Result as IoResult, Write};
 
-use crate::{TiEnumerated, TiRangeBounds, TiSlice, TiSliceIndex};
 #[cfg(all(feature = "alloc", feature = "serde"))]
 use serde::de::{Deserialize, Deserializer};
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
+
+use crate::{TiEnumerated, TiRangeBounds, TiSlice, TiSliceIndex};
 
 /// A contiguous growable array type
 /// that only accepts keys of the type `K`.
@@ -1251,8 +1252,7 @@ impl<K, V: bincode::enc::Encode> bincode::enc::Encode for TiVec<K, V> {
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        bincode::enc::Encode::encode(&self.raw, encoder)?;
-        Ok(())
+        bincode::enc::Encode::encode(&self.raw, encoder)
     }
 }
 
@@ -1263,8 +1263,7 @@ impl<C, K, V: bincode::de::Decode<C>> bincode::de::Decode<C> for TiVec<K, V> {
     fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        let raw: Vec<V> = bincode::Decode::<C>::decode(decoder)?;
-        Ok(raw.into())
+        Vec::decode(decoder).map(Into::into)
     }
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1256,8 +1256,8 @@ impl<K, V: bincode::enc::Encode> bincode::enc::Encode for TiVec<K, V> {
     }
 }
 
-#[cfg(feature = "bincode")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bincode")))]
+#[cfg(all(feature = "alloc", feature = "bincode"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc", feature = "bincode")))]
 impl<C, K, V: bincode::de::Decode<C>> bincode::de::Decode<C> for TiVec<K, V> {
     #[inline]
     fn decode<D: bincode::de::Decoder<Context = C>>(
@@ -1603,5 +1603,17 @@ mod test {
         assert_eq!(s0.as_slice().raw, [0; 0][..]);
         assert_eq!(s1.as_slice().raw, [12][..]);
         assert_eq!(s2.as_slice().raw, [23, 34][..]);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_encode_decode() {
+        let s0: TiVec<Id, u32> = TiVec::from(alloc::vec![0, 1, 2]);
+        let encode = bincode::encode_to_vec(&s0, bincode::config::standard()).unwrap();
+        let decode: TiVec<Id, u32> =
+            bincode::decode_from_slice(&encode, bincode::config::standard())
+                .unwrap()
+                .0;
+        assert_eq!(s0.as_slice().raw, decode.as_slice().raw);
     }
 }


### PR DESCRIPTION
Hey, thanks a lot for creating this library! It's extremely useful :) 

Recently we have started using ```bincode``` (https://github.com/bincode-org/bincode) to encode structs to a binary format. ```bincode``` has the advantage that it supports context aware deserialization.  

```bincode```'s ```Encode``` and ```Decode``` traits can in principle be derived automatically for ```TiVec<K, V>``` using the
```[bincode(with_serde)]``` attribute, but this requires ```V``` to implement ```Serialize/Deserialize```.  Thus having ```TiVec<K, V>``` implement ```Encode/Decode``` whenever ```V``` implements it would be the best option (behind an appropriate feature flag of course).  

Let me know what you think!



